### PR TITLE
Correctly set n_vols when directly creating Dataset

### DIFF
--- a/nipymc/data.py
+++ b/nipymc/data.py
@@ -16,7 +16,7 @@ class Dataset(object):
         self.design = design
         self.activation = activation
         self.TR = TR
-        self.n_vols = self.activation['vol'].max()
+        self.n_vols = self.activation['vol'].nunique()
         self.n_runs = self.activation['run'].nunique()
 
 


### PR DESCRIPTION
When creating a Dataset object directly (rather than using HCPDatasetFactory),
n_vols was initialized as the max() of the 'vol' column in the activation
dataset, but this only correctly counts n_vols if the vols are indexed from 1.
This commit initializes n_vols as the nunique() of 'vol', which works in the
0- or 1-indexed cases.
