### PR TITLE
add_term accepts list of variables

### DIFF
--- a/nipymc/model.py
+++ b/nipymc/model.py
@@ -286,8 +286,6 @@ class BayesianModel(object):
             split_dm = self._get_variable_data(split_by, True)
             dm = np.einsum('ab,ac->abc', dm, split_dm)
 
-        self.test = dm
-
         # Orthogonalization
         # TODO: generalize this to handle any combination of settings; right
         # now it will only work properly when both the target variable and the
@@ -479,14 +477,19 @@ class BayesianModel(object):
 
 class BayesianModelResults(object):
 
-    def __init__(self, trace, burn=0.5):
+    def __init__(self, trace):
         self.trace = trace
+
+    def summarize(self, terms=None, contrasts=None, burn=0.5):
+        # TODO: add a 'thin' parameter with argument k (default = 1) so that
+        # every kth sample is saved, the rest are discarded before summarizing
+
+        # handle burn whether it is given as a proportion or a number of samples
         if isinstance(burn, float):
-            n = trace.varnames[0]
+            n = self.trace.varnames[0]
             burn = round(len(trace[n]) * burn)
         self.burn = burn
 
-    def summarize(self, terms=None, contrasts=None):
         if terms is None:
             terms = self.trace.varnames
         summary = {'terms': {}, 'contrasts': {}}


### PR DESCRIPTION
Allows calls such as the following:

```
mod.add_term(['left_stim','right_stim'], label='stimulus',
    split_by='condition', random=True, categorical=True)
```

which can be used when multiple columns in `dataset.events` contain levels of the same factor (and there may be any degree of overlap in the levels that are contained in each column). Intended use case is for when multiple stimuli are presented simultaneously, as in the HCP Emotion task.

Also modifies BayesianModelResults so that `burn` is a parameter of `summarize()`, rather than `model.run()`, so the burn period can be changed after model fitting.
