### PR TITLE
Allow passing 'chain' argument to pymc3.run

### DIFF
--- a/nipymc/model.py
+++ b/nipymc/model.py
@@ -477,6 +477,7 @@ class BayesianModel(object):
         '''
         with self.model:
             njobs = kwargs.pop('njobs', 1)
+            chain = kwargs.pop('chain', 0)
             if isinstance(step, string_types):
                 step = {
                     'nuts': pm.NUTS,
@@ -487,7 +488,7 @@ class BayesianModel(object):
                                pm.find_MAP() if find_map else None)
             self.start = start
             trace = pm.sample(
-                samples, start=start, step=step, progressbar=verbose, njobs=njobs)
+                samples, start=start, step=step, progressbar=verbose, njobs=njobs, chain=chain)
             self.last_trace = trace  # for convenience
             return BayesianModelResults(trace)
 


### PR DESCRIPTION
Normally one will run multiple parallel MCMC chains by just setting
njobs > 1. But in some cases the parallelization must be done manually
(e.g., TACC doesn't seem to like it when you use njobs > 1). In those
cases you can run individual chains and then merge them later into a
MultiTrace object, provided that the chains have unique chain IDs. The
'chain' argument is used to set the chain IDs of individual chains.
