### PR TITLE
Dm plotting

### DIFF
--- a/nipymc/model.py
+++ b/nipymc/model.py
@@ -488,10 +488,11 @@ class BayesianModel(object):
         pass
 
     def plot_design_matrix(self, dm, variable, split_by=None, panel=False):
+        print(self.level_map.keys())
         import matplotlib.pyplot as plt
         import seaborn as sns
         n_cols = min(dm.shape[1], 10)
-        n_axes = dm.shape[-1]
+        n_axes = dm.shape[2]
         n_rows = self.dataset.n_vols * 3 * self.dataset.n_runs
         fig, axes = plt.subplots(n_axes, 1, figsize=(20, 2 * n_axes))
         if n_axes == 1:
@@ -503,9 +504,10 @@ class BayesianModel(object):
             for i in range(n_cols):
                 ax.plot(dm[:n_rows, i, j], c=colors[i], lw=2)
             ax.set_ylim(min_y - 0.05*min_y*np.sign(min_y), max_y + 0.05*max_y*np.sign(max_y))
-            try:
-                ax.set(xlabel=self.level_map[variable][j])
-            except: pass
+            if n_axes > 1:
+                try:
+                    ax.set(ylabel=list(self.level_map[split_by].keys())[j])
+                except: pass
         title = variable + ('' if split_by is None else ' split by ' + split_by)
         axes[0].set_title(title, fontsize=16)
         plt.show()


### PR DESCRIPTION
Adds improved plotting when adding new terms to the model. The plot argument to add_term() will now generate a much more useful line plot of the design matrix. Separate panels are displayed for different split_by levels. The number of unique lines is capped for manageability (to 10), as is the number of timepoints displayed (only the first 3 subjects' scans are shown).
