### PR TITLE
Fix bug causing user-supplied start values to be ignored

### DIFF
--- a/nipymc/model.py
+++ b/nipymc/model.py
@@ -447,7 +447,7 @@ class BayesianModel(object):
         self._setup_y(y_data, ar, by_run)
 
     def run(self, samples=1000, find_map=True, verbose=True, step='nuts',
-            start=None, burn=0.5, **kwargs):
+            burn=0.5, **kwargs):
         ''' Run the model.
         Args:
             samples (int): Number of MCMC samples to generate


### PR DESCRIPTION
model.run() included a named 'start' parameter for passing to the pymc3
sampler, but also had code that assumed 'start' would be part of kwargs,
with the result that user-supplied start values were always overwritten
by default values. This commit simply removes 'start' from the method
signature, so it will always be handled as a kwarg instead.
