### PR TITLE
Fix level_map issue

### DIFF
--- a/nipymc/model.py
+++ b/nipymc/model.py
@@ -42,9 +42,12 @@ class BayesianModel(object):
         ''' Extract (and cache) design matrix for variable/categorical combo.
         '''
 
-        # if variable is a list, convert it to tuple before hashing
-        cache_key = hash((tuple(variable) if isinstance(variable, list) else variable,
-                         categorical))
+        # assign default labels (for variables passed in via split_by or orthogonalize)
+        if label is None:
+            label = '_'.join(listify(variable))
+
+        # hash labels (rather than variables)
+        cache_key = hash((label, categorical))
 
         if cache_key not in self.cache:
 


### PR DESCRIPTION
When adding a fixed term that has already been indirectly referenced in a previous call to add_term (for example, through the split_by or orthogonalize arguments), the level mapping for the fixed term was never getting added to level_map. (But everything worked fine if the fixed term was added BEFORE ever getting referenced in a split_by or orthogonalize argument.) It turns out that this can be fixed by a fairly simple tweak to _get_variable_data, namely, assigning default labels to all 'variable' arguments and hashing labels rather than variables.
